### PR TITLE
Use image from cbioportal/cbioportal for automated tests

### DIFF
--- a/src/test/resources/local_database/setup_dockers.sh
+++ b/src/test/resources/local_database/setup_dockers.sh
@@ -49,7 +49,7 @@ migrate_db() {
     docker run --rm \
         --net=cbio-net \
         -v "$TEST_HOME/portal.properties:/cbioportal/portal.properties:ro" \
-        thehyve/cbioportal:rc \
+        cbioportal/cbioportal:master \
         python3 /cbioportal/core/src/main/scripts/migrate_db.py -y -p /cbioportal/portal.properties -s /cbioportal/db-scripts/src/main/resources/migration.sql
 
     cd $curdir


### PR DESCRIPTION
* Previously thehyve/cbioportal:rc was used temporarily because older cBioPortal versions than v3.0.0 did not have the -y option for the migrate_db.py script required for the automation tests.