### PR TITLE
add pip install step to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ ARG mvnprofiles=''
 RUN mvn clean install $mvnprofiles
 RUN mv $STAGING_HOME/target/cbioportal-staging-*.jar $STAGING_HOME/target/cbioportal-staging.jar
 
+# install python dependencies for transformation code
+RUN pip3 install -r $STAGING_HOME/transformation_requirements.txt
+
 # service to be started with default properties (can be overridden in docker run),
 # taking also custom properties, if given at default -v location
 ENTRYPOINT ["/cbioportal-staging/target/cbioportal-staging.jar", "--spring.config.location=file:///custom/custom.properties"]

--- a/transformation_requirements.txt
+++ b/transformation_requirements.txt
@@ -1,0 +1,3 @@
+pandas
+pyyaml
+numpy


### PR DESCRIPTION
installs libraries from `transformation_requirements.txt` to support the transformation script, which is running inside the staging container.

Future problems will be the Python version (3.5.4) in the openjdk8 docker environment, causing some pip libraries being outdated or not available.

For now this is the only feasible solution to a non-dockerized transformation script.